### PR TITLE
Fix file path/directory handling (during workflow generation and testing)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dev = [
 
 [project]
 name = "vibe-llama"
-version = "0.3.4"
+version = "0.3.5"
 description = "vibe-llama is a set of tools that are designed to help developers build working and reliable applications with LlamaIndex, LlamaCloud Services and llama-index-workflows."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/vibe_llama/docuflows/agent/__init__.py
+++ b/src/vibe_llama/docuflows/agent/__init__.py
@@ -64,7 +64,7 @@ from vibe_llama.docuflows.handlers.workflow_testing import (
 )
 
 # Import utility classes
-from vibe_llama.docuflows.commons import StreamEvent, validate_uuid
+from vibe_llama.docuflows.commons import StreamEvent, validate_uuid, is_file_path
 
 # Initialize rich console
 console = Console()
@@ -189,8 +189,8 @@ What kind of document processing workflow would you like to create?"""
         if user_input.lower() in ["quit", "exit", "bye"]:
             return StopEvent(result="👋 Goodbye!")
 
-        # Handle slash commands
-        if user_input.startswith("/"):
+        # Handle slash commands (but not file paths)
+        if user_input.startswith("/") and not is_file_path(user_input):
             return await handle_slash_command(ctx, user_input)
 
         # Handle help

--- a/src/vibe_llama/docuflows/commons/__init__.py
+++ b/src/vibe_llama/docuflows/commons/__init__.py
@@ -395,6 +395,30 @@ def clean_file_path(path: str) -> str:
     return os.path.abspath(path) if path else path
 
 
+def is_file_path(input_str: str) -> bool:
+    """
+    Determine if a string that starts with '/' is likely a file path rather than a command.
+    
+    Returns True if it's likely a file path, False if it's likely a command.
+    """
+    # Remove leading @ symbol if present
+    cleaned_path = input_str[1:] if input_str.startswith("@") else input_str
+    
+    # If it has multiple path components or file extensions, it's likely a path
+    if "/" in cleaned_path[1:] or "." in os.path.basename(cleaned_path):
+        return True
+    
+    # If it exists as a file or directory, it's a path
+    if os.path.exists(cleaned_path):
+        return True
+    
+    # If it looks like a Unix absolute path (not just "/command"), it's likely a path
+    if len(cleaned_path.split("/")) > 2:  # More than just "/" + single word
+        return True
+        
+    return False
+
+
 def validate_reference_path(path: str) -> tuple[bool, str, str]:
     """
     Validate a reference files path and provide helpful error messages.

--- a/src/vibe_llama/docuflows/commons/__init__.py
+++ b/src/vibe_llama/docuflows/commons/__init__.py
@@ -398,24 +398,24 @@ def clean_file_path(path: str) -> str:
 def is_file_path(input_str: str) -> bool:
     """
     Determine if a string that starts with '/' is likely a file path rather than a command.
-    
+
     Returns True if it's likely a file path, False if it's likely a command.
     """
     # Remove leading @ symbol if present
     cleaned_path = input_str[1:] if input_str.startswith("@") else input_str
-    
+
     # If it has multiple path components or file extensions, it's likely a path
     if "/" in cleaned_path[1:] or "." in os.path.basename(cleaned_path):
         return True
-    
+
     # If it exists as a file or directory, it's a path
     if os.path.exists(cleaned_path):
         return True
-    
+
     # If it looks like a Unix absolute path (not just "/command"), it's likely a path
     if len(cleaned_path.split("/")) > 2:  # More than just "/" + single word
         return True
-        
+
     return False
 
 

--- a/src/vibe_llama/docuflows/commons/core.py
+++ b/src/vibe_llama/docuflows/commons/core.py
@@ -190,12 +190,21 @@ async def load_reference_files(
             organization_id=organization_id,
         )
 
-        # Get all files in the directory, excluding system files and unsupported formats
-        all_files = [
-            f
-            for f in os.listdir(reference_files_path)
-            if os.path.isfile(os.path.join(reference_files_path, f))
-        ]
+        # Handle both single files and directories
+        if os.path.isfile(reference_files_path):
+            # Single file case
+            directory_path = os.path.dirname(reference_files_path)
+            filename = os.path.basename(reference_files_path)
+            all_files = [filename]
+            actual_reference_path = directory_path
+        else:
+            # Directory case
+            all_files = [
+                f
+                for f in os.listdir(reference_files_path)
+                if os.path.isfile(os.path.join(reference_files_path, f))
+            ]
+            actual_reference_path = reference_files_path
 
         # Filter out system files and keep only supported document types
         supported_extensions = {
@@ -235,7 +244,7 @@ async def load_reference_files(
 
         # Parse each file
         for filename in sorted(files):
-            file_path = os.path.join(reference_files_path, filename)
+            file_path = os.path.join(actual_reference_path, filename)
             try:
                 _send_event(ctx, f"Parsing reference file: {filename}")
 

--- a/src/vibe_llama/docuflows/handlers/workflow_generation.py
+++ b/src/vibe_llama/docuflows/handlers/workflow_generation.py
@@ -150,7 +150,12 @@ async def handle_generate_workflow(
 
     if not reference_files_path:
         return InputRequiredEvent(
-            prefix="Please provide the path to your reference files (directory or specific file): "  # type: ignore
+            prefix="Please provide the path to your reference files.\n"  # type: ignore
+            "This can be:\n"
+            "• A directory containing sample files (e.g., /path/to/reports/ or ./examples/)\n"
+            "• A specific file to use as reference (e.g., /path/to/sample.pdf or ./data/report.pdf)\n"
+            "• Use @ symbol for path completion (e.g., @data/ then press Tab)\n\n"
+            "Path: "
         )
 
     # Clean the reference files path (remove @ symbol if present)
@@ -168,7 +173,10 @@ async def handle_generate_workflow(
             )
         )
         return InputRequiredEvent(
-            prefix="Please provide a valid reference files path (directory or file): "  # type: ignore
+            prefix="Please provide a valid path to your reference files.\n"  # type: ignore
+            "This can be a directory containing sample files or a specific sample file.\n"
+            "Use @ symbol for path completion (e.g., @data/ then press Tab)\n\n"
+            "Path: "
         )
 
     # Show tool action with bold formatting - no truncation
@@ -195,8 +203,8 @@ async def handle_generate_workflow(
                 newline_after=True,
             )
         )
-        # For single files, we'll pass the parent directory to the workflow but note the specific file
-        reference_files_path = os.path.dirname(cleaned_path)
+        # Pass the actual file path for single files
+        reference_files_path = cleaned_path
     else:
         ctx.write_event_to_stream(
             StreamEvent(  # type: ignore

--- a/tests/docuflows/commons/test_commons_base.py
+++ b/tests/docuflows/commons/test_commons_base.py
@@ -7,6 +7,7 @@ from src.vibe_llama.docuflows.commons import (
     validate_uuid,
     validate_workflow_path,
     clean_file_path,
+    is_file_path,
     CLIFormatter,
     local_venv,
     install_deps,
@@ -59,6 +60,26 @@ def test_clean_file_path(reference_path: str) -> None:
     path2 = f"@/{reference_path}"
     assert "./" not in clean_file_path(path1)
     assert "@" not in clean_file_path(path2)
+
+
+def test_is_file_path() -> None:
+    """Test file path vs command detection"""
+    # File paths should return True
+    assert is_file_path("/Users/user/documents/file.pdf")
+    assert is_file_path("@data/test.pdf") 
+    assert is_file_path("/absolute/path/with/file.txt")
+    
+    # Commands should return False
+    assert not is_file_path("/help")
+    assert not is_file_path("/config")
+    assert not is_file_path("/model")
+
+
+def test_clean_file_path_with_at_symbol() -> None:
+    """Test @ symbol removal in file paths"""
+    assert clean_file_path("@data/test.pdf").endswith("data/test.pdf")
+    assert clean_file_path("/absolute/path.pdf") == os.path.abspath("/absolute/path.pdf")
+    assert "@" not in clean_file_path("@some/file.txt")
 
 
 def test_cli_formatter(test_text: str, reference_path: str) -> None:

--- a/tests/docuflows/commons/test_commons_base.py
+++ b/tests/docuflows/commons/test_commons_base.py
@@ -66,9 +66,9 @@ def test_is_file_path() -> None:
     """Test file path vs command detection"""
     # File paths should return True
     assert is_file_path("/Users/user/documents/file.pdf")
-    assert is_file_path("@data/test.pdf") 
+    assert is_file_path("@data/test.pdf")
     assert is_file_path("/absolute/path/with/file.txt")
-    
+
     # Commands should return False
     assert not is_file_path("/help")
     assert not is_file_path("/config")
@@ -78,7 +78,9 @@ def test_is_file_path() -> None:
 def test_clean_file_path_with_at_symbol() -> None:
     """Test @ symbol removal in file paths"""
     assert clean_file_path("@data/test.pdf").endswith("data/test.pdf")
-    assert clean_file_path("/absolute/path.pdf") == os.path.abspath("/absolute/path.pdf")
+    assert clean_file_path("/absolute/path.pdf") == os.path.abspath(
+        "/absolute/path.pdf"
+    )
     assert "@" not in clean_file_path("@some/file.txt")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2266,7 +2266,7 @@ wheels = [
 
 [[package]]
 name = "vibe-llama"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
A few quality of life nits:

1. when passing in a reference file during workflow generation: a) allow users to pass in a single file instead of requiring a directory, and b) allow absolute paths

2. when testing a workflow, allow users to specify the @ symbol 