### PR TITLE
fix: correct instructions base url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
 
 [project]
 name = "vibe-llama"
-version = "0.4.1"
+version = "0.4.1.post1"
 description = "vibe-llama is a set of tools that are designed to help developers build working and reliable applications with LlamaIndex, LlamaCloud Services and llama-index-workflows."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/vibe_llama/constants.py
+++ b/src/vibe_llama/constants.py
@@ -1,2 +1,2 @@
 CHUNKS_SEPARATOR = "<!-- sep---sep -->"
-BASE_URL = "https://raw.githubusercontent.com/run-llama/vibe-llama/clelia/workflows-scaffolding"
+BASE_URL = "https://raw.githubusercontent.com/run-llama/vibe-llama/main"


### PR DESCRIPTION
Corrects base instructions URL pointing it back to the main branch of the repo.

Closes #16
