### PR TITLE
fix: core package publishing

### DIFF
--- a/.github/workflows/release_core.yml
+++ b/.github/workflows/release_core.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build
         working-directory: packages/vibe-llama-core/
-        run: uv build
+        run: uv build -o dist
 
       - name: Publish to PyPI
         working-directory: packages/vibe-llama-core/


### PR DESCRIPTION
Fixing vibe-llama-core publishing action by specifying the output directory for the build
