### PR TITLE
Changing logo colors, adding an MCP config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ generated_workflows/
 .claude/
 CLAUDE.md
 .github/copilot-instructions.md
+.mcp.json
+AGENTS.md
 
 # data folder
 data/invoices/

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ On the TUI, you will be asked for what skills you want to download.
 >
 > _Find out more about skills [on Claude Code documentation](https://docs.claude.com/en/docs/claude-code/skills)_
 
+If you provide the `--allow_mcp_config` option, you will also download a generic MCP configuration (supported natively by Claude Code and Cursor), that will give you access to the local MCP provided by vibe-llama and to the general MCP provided by LlamaIndex over the entire documentation. This configuration can be easily adapted to other coding agents and can be saved to a specific path by providing the `--mcp_config_path` option (the default is `.mcp.json`).
+
 With `starter`, you can also launch a local MCP server (at http://127.0.0.1:8000/mcp) using the `-m`/`--mcp` flag. This server exposes a tool (`get_relevant_context`) that allows you to retrieve relevant documentation content based on a specific query. If you are interested in interacting with vibe-llama MCP programmatically, you can check the [SDK guide](#vibellamamcpclient).
 
 **Example usage**
@@ -98,6 +100,8 @@ With `starter`, you can also launch a local MCP server (at http://127.0.0.1:8000
 vibe-llama starter # Launch a TUI
 vibe-llama starter -a 'GitHub Copilot' -s LlamaIndex -v # Select GitHub Copilot and LlamaIndex and enable verbose logging
 vibe-llama starter -a 'Claude Code' -s llama-index-workflows -w # Select Claude Code and llama-index-workflows and allow to overwrite the existing CLAUDE.md
+vibe-llama starter -a 'Claude Code' -s llama-index-workflows --skill "PDF Parsing" --skill "Llamactl Usage" -w # download skills
+vibe-llama stater  -a 'Claude Code' -s llama-index-workflows --allow_mcp_config --mcp_config_path .claude/mcp.json # download the MCP configuration
 vibe-llama starter --mcp # Launch an MCP server
 ```
 

--- a/packages/vibe-llama-core/pyproject.toml
+++ b/packages/vibe-llama-core/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
 
 [project]
 name = "vibe-llama-core"
-version = "0.1.1.post1"
+version = "0.2.0"
 description = "vibe-llama-core is a reduced version of vibe-llama containing only the code for downloading documentation and templates."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/vibe-llama-core/src/vibe_llama_core/docs/data.py
+++ b/packages/vibe-llama-core/src/vibe_llama_core/docs/data.py
@@ -47,3 +47,21 @@ claude_code_skills: list[ClaudeCodeSkill] = [
     {"skill_md_url": f"{BASE_URL}/documentation/skills/text-classification/SKILL.md", "reference_md_url": f"{BASE_URL}/documentation/skills/text-classification/REFERENCE.md", "local_path": ".claude/skills/text-classification/", "name": "Text Classification"},
     {"skill_md_url": f"{BASE_URL}/documentation/skills/llamactl/SKILL.md", "reference_md_url": f"{BASE_URL}/documentation/skills/llamactl/REFERENCE.md", "local_path": ".claude/skills/llamactl/", "name": "Llamactl Usage"}
 ]
+
+mcp_config = {
+  "mcpServers": {
+    "vibe-llama": {
+      "type": "http",
+      "command": "vibe-llama",
+      "args": [
+        "starter",
+        "--mcp",
+      ],
+      "env": {}
+    },
+    "llama-index-docs": {
+      "type": "http",
+      "url": "https://developers.llamaindex.ai/mcp"
+    }
+  }
+}

--- a/packages/vibe-llama-core/src/vibe_llama_core/docs/utils.py
+++ b/packages/vibe-llama-core/src/vibe_llama_core/docs/utils.py
@@ -1,4 +1,5 @@
 import os
+import json
 import warnings
 import httpx
 import asyncio
@@ -6,7 +7,7 @@ import asyncio
 from typing import Optional
 from pathlib import Path
 from vibe_llama_core.constants import CHUNKS_SEPARATOR
-from .data import services, agent_rules, LibraryName, claude_code_skills
+from .data import services, agent_rules, LibraryName, claude_code_skills, mcp_config
 
 def write_file(
     file_path: str, content: str, overwrite_file: bool, service_url: str
@@ -108,10 +109,70 @@ async def get_claude_code_skills(
         )
     return None
 
+def write_mcp_config(mcp_config_path: Optional[str], overwrite: Optional[bool]) -> None:
+    """
+    Write the configuration for a local MCP server with high-level, curated documentation (vibe-llama) and a global MCP server with access to the whole LlamaIndex documentation (llama-index-docs).
+
+    Args:
+        mcp_config_path (Optional[str]): Path to the file to be written. Defaults to .mcp.json if not provided
+        overwrite (Optional[bool]): Whether to overwrite existing files or not. Defaults to False.
+    """
+    path = ".mcp.json"
+    if mcp_config_path is not None:
+        path = mcp_config_path
+    if overwrite:
+        if Path(path).suffix:
+            if  Path(path).suffix == ".json":
+                if not Path(path).parent.exists():
+                    os.makedirs(Path(path).parent, exist_ok=True)
+                with open(path, "w") as f:
+                    json.dump(mcp_config, f, indent=2)
+                print("SUCCESS✅\tMCP configation file has been written, happy vibe-hacking!")
+            else:
+               raise ValueError("The MCP configuration file must be a JSON")
+        else:
+            warnings.warn(f"Writing to file {path}/.mcp.json because the provided path is likely a directory", UserWarning)
+            if not Path(path).exists():
+                os.makedirs(path, exist_ok=True)
+            with open(path + "/.mcp.json", "w") as f:
+                json.dump(mcp_config, f, indent=2)
+            print("SUCCESS✅\tMCP configation file has been written, happy vibe-hacking!")
+    else:
+        if Path(path).exists() and Path(path).is_file():
+            raise FileExistsError(f"Cannot write to file {path} because it already exists. If you wish to overwrite, give permission by specifying it either in the terminal interface or from command line.")
+        else:
+            if Path(path).exists() and Path(path).is_dir():
+                warnings.warn(f"Trying to write the configuration to file {path}/.mcp.json because the provided path is a directory", UserWarning)
+                if Path(path + "/.mcp.json").exists():
+                    raise FileExistsError(f"Attempt to write  the configuration to file {path}/.mcp.json failed: the file already exists")
+                else:
+                    with open(path + "/.mcp.json", "w") as f:
+                        json.dump(mcp_config, f, indent=2)
+                    print("SUCCESS✅\tMCP configation file has been written, happy vibe-hacking!")
+            elif not Path(path).exists():
+                if Path(path).suffix:
+                    if Path(path).suffix == ".json":
+                        if not Path(path).parent.exists():
+                            os.makedirs(Path(path).parent, exist_ok=True)
+                        with open(path, "w") as f:
+                            json.dump(mcp_config, f, indent=2)
+                        print("SUCCESS✅\tMCP configation file has been written, happy vibe-hacking!")
+                    else:
+                        raise ValueError("The MCP configuration file must be a JSON")
+                else:
+                    warnings.warn(f"Writing to file {path}/.mcp.json because the provided path is likely a directory", UserWarning)
+                    os.makedirs(path, exist_ok=True)
+                    with open(path + "/.mcp.json", "w") as f:
+                        json.dump(mcp_config, f, indent=2)
+                    print("SUCCESS✅\tMCP configation file has been written, happy vibe-hacking!")
+    return None
+
 async def get_agent_rules(
     agent: str,
     service: LibraryName,
     skills: list[str] = [],
+    allow_mcp_config: Optional[bool] = None,
+    mcp_config_path: Optional[str] = None,
     overwrite_files: Optional[bool] = None,
     verbose: Optional[bool] = None,
 ) -> None:
@@ -121,6 +182,9 @@ async def get_agent_rules(
     Args:
         agent (str): Coding agent for which rules should be downloaded
         service (LibraryName): Service for which rules should be downloaded (LlamaIndex, LlamaIndex Workflows, LlamaCloud Services)
+        skills (list[str]): List of names of the skills to download (only allowed for Claude Code).
+        allow_mcp_config (Optional[bool]): Allow a generic MCP configuration to be written to a a specific path. Defaults to False.
+        mcp_config_path (Optional[str]): Path to write the MCP configuration to. Only applied if `allow_mcp_config` is True, defaults to .mcp.json.
         overwrite_files (Optional[bool]): Whether or not to overwrite existing rule files.
         verbose (Optional[bool]): Enable verbose logging.
     """
@@ -153,4 +217,6 @@ async def get_agent_rules(
         await get_claude_code_skills(skills, overwrite_files, verbose)
     elif skills and agent != "Claude Code":
         warnings.warn("Skills are not available for agents other than Claude Code.", UserWarning)
+    if allow_mcp_config:
+        write_mcp_config(mcp_config_path, overwrite_files)
     return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ dev = [
 
 [project]
 name = "vibe-llama"
-version = "0.4.7.post1"
+version = "0.5.0"
 description = "vibe-llama is a set of tools that are designed to help developers build working and reliable applications with LlamaIndex, LlamaCloud Services and llama-index-workflows."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "vibe-llama-core>=0.1.1.post1",
+  "vibe-llama-core>=0.2.0",
   "bm25s>=0.2.13",
   "fastmcp>=2.11.3",
   "llama-cloud-services>=0.6.62",

--- a/src/vibe_llama/logo.py
+++ b/src/vibe_llama/logo.py
@@ -15,7 +15,7 @@ def print_logo() -> None:
     cs = Console()
     print("\n")
     cs.print(
-        Text(logo, colors=["#F8E9D8", "#FFA6EA", "#45DFF8", "#BB8DEB"]),
+        Text(logo, colors=["#4B72FE", "#FF8DF2", "#FF8705"]),
         justify="center",
     )
     print("\n")

--- a/src/vibe_llama/main.py
+++ b/src/vibe_llama/main.py
@@ -74,6 +74,21 @@ def main() -> None:
     )
 
     starter_parser.add_argument(
+        "--allow_mcp_config",
+        action="store_true",
+        help="Allow downloading an MCP config for your coding agent",
+        required=False,
+        default=False,
+    )
+
+    starter_parser.add_argument(
+        "--mcp_config_path",
+        help="Path to write the downloaded MCP configuration to. Only works in combination with --allow-mcp-config. Defaults to .mcp.json",
+        required=False,
+        default=None,
+    )
+
+    starter_parser.add_argument(
         "-w",
         "--overwrite",
         action="store_true",
@@ -115,7 +130,13 @@ def main() -> None:
         if not args.mcp:
             t = asyncio.run(
                 starter(
-                    args.agent, args.service, args.skill, args.overwrite, args.verbose
+                    args.agent,
+                    args.service,
+                    args.skill,
+                    args.allow_mcp_config,
+                    args.mcp_config_path,
+                    args.overwrite,
+                    args.verbose,
                 )
             )
             if t:

--- a/src/vibe_llama/sdk/base.py
+++ b/src/vibe_llama/sdk/base.py
@@ -6,6 +6,7 @@ from vibe_llama_core.docs.utils import (
     write_file,
     get_instructions,
     get_claude_code_skills,
+    write_mcp_config,
 )
 from vibe_llama_core.docs.data import (
     LibraryName,
@@ -35,16 +36,23 @@ class VibeLlamaStarter:
         agents: List[str],
         services: List[LibraryName],
         skills: List[str] = [],
+        allow_mcp_config: bool = False,
+        mcp_config_path: Optional[str] = None,
     ) -> None:
         """
         Initialize VibeLlamaStarter.
 
         Args:
             agents (List[str]): List of coding agents to write instructions for.
-            services ( List[LibraryName]): List of services to fetch instructions from.
+            services (List[LibraryName]): List of services to fetch instructions from.
+            skills (List[str]): List of skills to download. Only applies if "Claude Code" is among the chosen agents.
+            allow_mcp_config (bool): Whether or not to download a general MCP configuration for your coding agent.
+            mcp_config_path (Optional[str]): Path to the MCP configuration. Only applies if `allow_mcp_config` is set to True.
         """
         self.agent_files = [agent_rules[agent] for agent in agents]
         self.service_urls = [service_to_url[service] for service in services]
+        self.allow_mcp_config = allow_mcp_config
+        self.mcp_config_path = mcp_config_path
         if "Claude Code" not in agents:
             warnings.warn(
                 "Skills are not available for agents other than Claude Code.",
@@ -114,6 +122,8 @@ class VibeLlamaStarter:
         )
         if self.skills:
             await get_claude_code_skills(self.skills, overwrite, verbose)
+        if self.allow_mcp_config:
+            write_mcp_config(self.mcp_config_path, overwrite)
         return None
 
 

--- a/src/vibe_llama/starter/__init__.py
+++ b/src/vibe_llama/starter/__init__.py
@@ -7,6 +7,7 @@ from vibe_llama_core.docs.utils import (
     write_file,
     get_instructions,
     get_claude_code_skills,
+    write_mcp_config,
 )
 from vibe_llama_core.docs.data import agent_rules, services, LibraryName
 
@@ -15,6 +16,8 @@ async def starter(
     agent: Optional[str] = None,
     service: Optional[LibraryName] = None,
     download_skills: Optional[list[str]] = None,
+    allow_mcp_config: Optional[bool] = None,
+    mcp_config_path: Optional[str] = None,
     overwrite_files: Optional[bool] = None,
     verbose: Optional[bool] = None,
 ) -> bool:
@@ -26,7 +29,14 @@ async def starter(
                 "[bold red]ERROR[/]\tYou need to choose at least one agent and one service before continuining. Exiting..."
             )
             return False
-        agent_files, service_urls, download_skills, overwrite_files = term_res
+        (
+            agent_files,
+            service_urls,
+            download_skills,
+            overwrite_files,
+            allow_mcp_config,
+            mcp_config_path,
+        ) = term_res
         if agent_files is None or service_urls is None:
             cs.log(
                 "[bold red]ERROR[/]\tYou need to choose at least one agent and one service before continuining. Exiting..."
@@ -74,6 +84,8 @@ async def starter(
             cs.log(
                 "[bold yellow]WARNING:[/]\tSkills are not available for agents other than Claude Code."
             )
+    if allow_mcp_config:
+        write_mcp_config(mcp_config_path, overwrite_files)
     return ".vibe-llama/rules/AGENTS.md" in agent_files
 
 

--- a/src/vibe_llama/starter/terminal.py
+++ b/src/vibe_llama/starter/terminal.py
@@ -1,5 +1,4 @@
-from prompt_toolkit.shortcuts import checkboxlist_dialog
-from prompt_toolkit.shortcuts import yes_no_dialog
+from prompt_toolkit.shortcuts import checkboxlist_dialog, yes_no_dialog, input_dialog
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.styles import Style
 from typing import Optional, Tuple, List, cast
@@ -33,12 +32,29 @@ app2 = checkboxlist_dialog(
 app2a = checkboxlist_dialog(
     title=HTML("<style fg='black'>Donwload Skills</style>"),
     text="Since you chose Claude Code as your coding agent, would you also like to download any of these Claude Skills?",
-    values=[(skill["name"], skill["name"]) for skill in claude_code_skills],
+    values=[("no", "No, I would not like to")]
+    + [(skill["name"], skill["name"]) for skill in claude_code_skills],
     cancel_text="Go Back",
     style=style,
 )
 
 app3 = yes_no_dialog(
+    title=HTML("<style fg='black'>MCP Config</style>"),
+    text="Do you wish to add a general MCP configuration file?",
+    style=style,
+)
+
+app3a = input_dialog(
+    title=HTML("<style fg='black'>MCP Config Path</style>"),
+    text=HTML(
+        "Which path would you like to save the MCP configuration to? (leave blank to save to <style bg='gray'>.mcp.json</style>)"
+    ),
+    style=style,
+    cancel_text="",
+    default="",
+)
+
+app4 = yes_no_dialog(
     title=HTML("<style fg='black'>Overwrite</style>"),
     text="Do you want to overwrite existing files?",
     style=style,
@@ -46,24 +62,38 @@ app3 = yes_no_dialog(
 
 
 async def run_terminal_interface() -> Optional[
-    Tuple[List[str], List[str], List[str], bool]
+    Tuple[List[str], List[str], List[str], bool, bool, Optional[str]]
 ]:
     results_array1 = None
     results_array2 = None
     overwrite = False
     download_skills = None
+    mcp_config_path = None
+    allow_mcp_config = False
 
     while not results_array2:
         results_array1 = await app1.run_async()
         if not results_array1:
             return None
-        results_array2 = await app2.run_async()
         if "CLAUDE.md" in results_array1:
-            download_skills = await app2a.run_async()
-        overwrite = await app3.run_async()
+            while not download_skills:
+                results_array2 = await app2.run_async()
+                download_skills = await app2a.run_async()
+        else:
+            results_array2 = await app2.run_async()
+        allow_mcp_config = await app3.run_async()
+        if allow_mcp_config:
+            mcp_config_path = await app3a.run_async()
+        overwrite = await app4.run_async()
+    if download_skills == ["no"]:
+        download_skills = None
+    if mcp_config_path == "":
+        mcp_config_path = None
     return (
         cast(List[str], results_array1),
         results_array2,
         download_skills or [],
         overwrite,
+        allow_mcp_config,
+        mcp_config_path,
     )

--- a/tests/sdk/test_starter.py
+++ b/tests/sdk/test_starter.py
@@ -70,8 +70,30 @@ async def test_write_instructions_claude_skills(
         services=["LlamaIndex", "llama-index-workflows"],
         skills=["PDF Parsing"],
     )
+    cwd = Path.cwd()
     os.chdir(tmp_path)
     await starter.write_instructions()
     assert (tmp_path / ".claude/skills/pdf-processing/SKILL.md").exists()
     assert (tmp_path / ".claude/skills/pdf-processing/REFERENCE.md").exists()
     mock.assert_called()
+    os.chdir(cwd)
+
+
+@pytest.mark.asyncio
+async def test_write_instructions_mcp_config(tmp_path: Path) -> None:
+    starter = VibeLlamaStarter(
+        agents=["Claude Code"],
+        services=["llama-index-workflows"],
+        allow_mcp_config=True,
+    )
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    await starter.write_instructions()
+    assert (tmp_path / ".mcp.json").exists()
+    with pytest.raises(FileExistsError):
+        await starter.write_instructions()
+    starter.mcp_config_path = "mcp.json"
+    starter.allow_mcp_config = False
+    await starter.write_instructions()
+    assert not (tmp_path / "mcp.json").exists()
+    os.chdir(cwd)

--- a/tests/starter/test_base.py
+++ b/tests/starter/test_base.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, AsyncMock
 
 from typing import Any
 from vibe_llama.starter import starter
-from vibe_llama.starter.terminal import app1, app2, app3, app2a
+from vibe_llama.starter.terminal import app1, app2, app3, app2a, app3a, app4
 from prompt_toolkit.application import Application
 from vibe_llama_core.docs import claude_code_skills
 
@@ -89,8 +89,32 @@ async def test_starter_skills_not_claude(mock: AsyncMock) -> None:
     mock.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_starter_mcp_config(tmp_path: Path) -> None:
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    await starter(
+        agent="Claude Code", service="llama-index-workflows", allow_mcp_config=True
+    )
+    assert (tmp_path / ".mcp.json").exists()
+    with pytest.raises(FileExistsError):
+        await starter(
+            agent="Claude Code", service="llama-index-workflows", allow_mcp_config=True
+        )
+    await starter(
+        agent="Claude Code",
+        service="llama-index-workflows",
+        allow_mcp_config=False,
+        mcp_config_path="mcp.json",
+    )
+    assert not (tmp_path / "mcp.json").exists()
+    os.chdir(cwd)
+
+
 def test_terminal_apps() -> None:
     assert isinstance(app1, Application)
     assert isinstance(app2, Application)
     assert isinstance(app3, Application)
+    assert isinstance(app3a, Application)
     assert isinstance(app2a, Application)
+    assert isinstance(app4, Application)

--- a/uv.lock
+++ b/uv.lock
@@ -3245,7 +3245,7 @@ wheels = [
 
 [[package]]
 name = "vibe-llama"
-version = "0.4.6"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "bm25s" },
@@ -3298,7 +3298,7 @@ dev = [
 
 [[package]]
 name = "vibe-llama-core"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/vibe-llama-core" }
 dependencies = [
     { name = "copier" },


### PR DESCRIPTION
This PR:

- Changes the colors of the logo to align to the current brand
- Introduces the possibility of downloading an MCP configuration for vibe-llama MCP and the LlamaIndex Docs MCP
- Fixes a bug in the starter terminal interface	
