### PR TITLE
Fix incomplete file info list for directory scanning

### DIFF
--- a/src/vibe_llama/docuflows/handlers/workflow_generation.py
+++ b/src/vibe_llama/docuflows/handlers/workflow_generation.py
@@ -53,9 +53,9 @@ async def assess_document_complexity(
 
     # Limit to first 15 files to keep prompt manageable
     if len(file_info) > 15:
-        file_info = file_info[:15] + [f"... and {len(file_info) - 15} more files"]
-
-    files_str = "\n".join(file_info) if file_info else "No files found"
+        files_str = "\n".join(file_info[:15]) + f"\n... and {len(file_info) - 15} more files"
+    else:
+        files_str = "\n".join(file_info) if file_info else "No files found"
 
     complexity_prompt = """Analyze this document processing task and reference files to recommend LlamaParse and LlamaExtract configurations.
 


### PR DESCRIPTION
The previous implementation appended a string description (`"... and X more files"`) directly to the `file_info` list. This caused issues because the list contained both actual file paths and a descriptive string, which would break downstream logic expecting only valid paths or cause confusing output when joined with newlines.

This fix ensures that if the limit is exceeded, the `files_str` is constructed by joining the first 15 paths and then appending the description as a separate line in the final string, rather than polluting the list of file references.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.